### PR TITLE
Add a command for interactively changing the status of an issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ GOJI-21 Update core metrics
 GOJI-40 Remove expired food from fridge
 ```
 
+### change-status
+
+Change the status of an issue
+
+```bash
+$ goji change-status GOJI-311
+Fetching possible transitions...
+0: To Do
+1: In Progress
+2: Done
+Select a transition: 1
+Okay, the status for GOJI-311 is now "In Progress".
+```
+
 ## License
 
 goji is released under the BSD license. See [LICENSE](LICENSE).

--- a/goji/client.py
+++ b/goji/client.py
@@ -3,7 +3,7 @@ import json
 import requests
 from requests.compat import urljoin
 
-from goji.models import Issue
+from goji.models import Issue, Transition
 from goji.auth import get_credentials
 
 
@@ -27,6 +27,18 @@ class JIRAClient(object):
         url = urljoin(self.rest_base_url, 'issue/%s' % issue_key)
         request = requests.get(url, auth=self.auth)
         return Issue.from_json(request.json())
+
+    def get_issue_transitions(self, issue_key):
+        url = urljoin(self.rest_base_url, 'issue/%s/transitions' % issue_key)
+        request = requests.get(url, auth=self.auth)
+        return map(Transition.from_json, request.json()['transitions'])
+
+    def change_status(self, issue_key, transition_id):
+        url = urljoin(self.rest_base_url, 'issue/%s/transitions' % issue_key)
+        headers = {'content-type': 'application/json'}
+        data = json.dumps({'transition': {'id': transition_id}})
+        request = requests.post(url, data=data, headers=headers, auth=self.auth)
+        return (request.status_code == 204)
 
     def edit_issue(self, issue_key, updated_fields):
         url = urljoin(self.rest_base_url, 'issue/%s' % issue_key)

--- a/goji/commands.py
+++ b/goji/commands.py
@@ -83,6 +83,31 @@ def unassign(client, issue_key):
 
 
 @click.argument('issue_key')
+@cli.command('change-status')
+@click.pass_obj
+def change_status(client, issue_key):
+    """Change the status of an issue"""
+    print('Fetching possible transitions...')
+    transitions = client.get_issue_transitions(issue_key)
+    if len(transitions) == 0:
+        print('No transitions found for {}'.format(issue_key))
+        return
+
+    for index, transition in enumerate(transitions):
+        print('{}: {}'.format(index, transition))
+    index = click.prompt('Select a transition', type=int)
+    if index < 0 or index >= len(transitions):
+        print('No transitions match "{}"'.format(index))
+        return
+
+    transition = transitions[index]
+    if client.change_status(issue_key, transition.id):
+        print('Okay, the status for {} is now "{}".'.format(issue_key, transition))
+    else:
+        print('There was an issue saving the new status as "{}"'.format(transition))
+
+
+@click.argument('issue_key')
 @cli.command()
 @click.pass_obj
 def comment(client, issue_key):

--- a/goji/commands.py
+++ b/goji/commands.py
@@ -82,10 +82,11 @@ def unassign(client, issue_key):
         print('There was a problem unassigning {}.'.format(issue_key))
 
 
+@click.argument('status', required=False)
 @click.argument('issue_key')
 @cli.command('change-status')
 @click.pass_obj
-def change_status(client, issue_key):
+def change_status(client, issue_key, status):
     """Change the status of an issue"""
     print('Fetching possible transitions...')
     transitions = client.get_issue_transitions(issue_key)
@@ -93,12 +94,21 @@ def change_status(client, issue_key):
         print('No transitions found for {}'.format(issue_key))
         return
 
-    for index, transition in enumerate(transitions):
-        print('{}: {}'.format(index, transition))
-    index = click.prompt('Select a transition', type=int)
-    if index < 0 or index >= len(transitions):
-        print('No transitions match "{}"'.format(index))
-        return
+    if status is None:
+        for index, transition in enumerate(transitions):
+            print('{}: {}'.format(index, transition))
+        index = click.prompt('Select a transition', type=int)
+        if index < 0 or index >= len(transitions):
+            print('No transitions match "{}"'.format(index))
+            return
+    else:
+        index = -1
+        for idx, transition in enumerate(transitions):
+            if transition.name.lower() == status.lower():
+                index = idx
+        if index < 0:
+            print('No transitions match "{}"'.format(status))
+            return
 
     transition = transitions[index]
     if client.change_status(issue_key, transition.id):

--- a/goji/models.py
+++ b/goji/models.py
@@ -65,6 +65,19 @@ class IssueLink(Model):
     def __str__(self):
         pass
 
+
+class Transition(Model):
+    @classmethod
+    def from_json(cls, json):
+        return cls(json['id'], json['name'])
+
+    def __init__(self, identifier, name):
+        self.id = identifier
+        self.name = name
+
+    def __str__(self):
+        return self.name
+
 """
 class IssueType(object):
     id

--- a/tests/models/test_transition.py
+++ b/tests/models/test_transition.py
@@ -1,0 +1,29 @@
+import unittest
+from goji.models import Transition
+
+
+class TransitionTests(unittest.TestCase):
+    def test_transition_creation_from_json(self):
+        json = {
+            'to': {
+                'statusCategory': {
+                    'name': 'In Progress',
+                    'self': 'https://example.net/rest/api/2/statuscategory/4',
+                    'id': 4,
+                    'key': 'indeterminate',
+                    'colorName': 'yellow'
+                },
+                'description': 'This issue is being actively worked on.',
+                'self': 'https://example.net/rest/api/2/status/3',
+                'iconUrl': 'https://example.net/icons/statuses/inprogress.png',
+                'id': '3',
+                'name': 'In Progress'
+            },
+            'hasScreen': False,
+            'id': '21',
+            'name': 'In Progress'
+        }
+        transition = Transition.from_json(json)
+
+        self.assertEqual(transition.name, 'In Progress')
+        self.assertEqual(transition.id, '21')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -80,3 +80,17 @@ class ChangeStatusCommandTests(unittest.TestCase):
         result = runner.invoke(cli, args, obj=TestClient(), input='1\n')
         self.assertIsNone(result.exception)
         self.assertEqual(result.output, 'Fetching possible transitions...\n0: Unstarted\n1: Going\n2: Done\nSelect a transition: 1\nOkay, the status for GOJI-311 is now "Going".\n')
+
+    def test_change_status_specify_invalid_status_name(self):
+        runner = CliRunner()
+        args = ['--base-url=https://example.com', 'change-status', 'GOJI-311', 'foo']
+        result = runner.invoke(cli, args, obj=TestClient())
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.output, 'Fetching possible transitions...\nNo transitions match "foo"\n')
+
+    def test_change_status_specify_valid_status_name(self):
+        runner = CliRunner()
+        args = ['--base-url=https://example.com', 'change-status', 'GOJI-311', 'done']
+        result = runner.invoke(cli, args, obj=TestClient())
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.output, 'Fetching possible transitions...\nOkay, the status for GOJI-311 is now "Done".\n')

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,7 +4,7 @@ import os
 from click.testing import CliRunner
 
 from goji.commands import cli
-from goji.models import Issue
+from goji.models import Issue, Transition
 
 
 class TestClient(object):
@@ -22,6 +22,17 @@ class TestClient(object):
         issue.assignee = 'kyle'
         issue.links = []
         return issue
+
+    def get_issue_transitions(self, issue_key):
+        if issue_key == 'invalid':
+            return []
+        else:
+            return [Transition('31', 'Unstarted'),
+                    Transition('21', 'Going'),
+                    Transition('1', 'Done')]
+
+    def change_status(self, issue_key, transition_id):
+        return True
 
 
 class CLITests(unittest.TestCase):
@@ -47,3 +58,25 @@ class ShowCommandTests(unittest.TestCase):
 
         self.assertEqual(result.output, '-> XX-123\n  Example issue\n\n  - Status: Open\n  - Creator: kyle\n  - Assigned: kyle\n  - URL: https://goji.example.com/browse/XX-123\n')
         self.assertEqual(result.exit_code, 0)
+
+class ChangeStatusCommandTests(unittest.TestCase):
+    def test_change_status_invalid_issue_key(self):
+        runner = CliRunner()
+        args = ['--base-url=https://example.com', 'change-status', 'invalid']
+        result = runner.invoke(cli, args, obj=TestClient())
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.output, 'Fetching possible transitions...\nNo transitions found for invalid\n')
+
+    def test_change_status_valid_issue_key_invalid_input(self):
+        runner = CliRunner()
+        args = ['--base-url=https://example.com', 'change-status', 'GOJI-311']
+        result = runner.invoke(cli, args, obj=TestClient(), input='3\n')
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.output, 'Fetching possible transitions...\n0: Unstarted\n1: Going\n2: Done\nSelect a transition: 3\nNo transitions match "3"\n')
+
+    def test_change_status_valid_issue_key_valid_input(self):
+        runner = CliRunner()
+        args = ['--base-url=https://example.com', 'change-status', 'GOJI-311']
+        result = runner.invoke(cli, args, obj=TestClient(), input='1\n')
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.output, 'Fetching possible transitions...\n0: Unstarted\n1: Going\n2: Done\nSelect a transition: 1\nOkay, the status for GOJI-311 is now "Going".\n')


### PR DESCRIPTION
Changing the status requires knowing the identifier of the transition which needs to be performed. So this command does two requests, one to fetch possible transitions and a second to post the change based on the user's selection.