### PR TITLE
fix: Use inward issue instead of outward if available

### DIFF
--- a/goji/models.py
+++ b/goji/models.py
@@ -56,7 +56,10 @@ class IssueLink(Model):
     @classmethod
     def from_json(cls, json):
         link_type = IssueLinkType.from_json(json['type'])
-        return cls(link_type, Issue.from_json(json['outwardIssue']))
+        if 'outwardIssue' in json:
+            return cls(link_type, Issue.from_json(json['outwardIssue']))
+
+        return cls(link_type, Issue.from_json(json['inwardIssue']))
 
     def __init__(self, link_type, outward_issue):
         self.link_type = link_type


### PR DESCRIPTION
In some cases, issue links are unidirectional, so there may be an
'inward' issue without an 'outward' issue.

Fixes KeyError for outwardIssue when creating links