### PR TITLE
Support some SSO variant

### DIFF
--- a/goji/client.py
+++ b/goji/client.py
@@ -32,7 +32,10 @@ class JIRAClient(object):
                 print('warning: Could not load cookies from dist: ' + e)
 
     def save_cookies(self):
-        if len(self.session.cookies) > 0:
+        cookies = self.session.cookies.keys()
+        cookies.remove('atlassian.xsrf.token')
+
+        if len(cookies) > 0:
             os.makedirs(os.path.expanduser('~/.goji'), exist_ok=True)
 
             with open(self.cookie_path, 'wb') as fp:

--- a/goji/client.py
+++ b/goji/client.py
@@ -1,3 +1,5 @@
+import os
+import pickle
 import json
 
 import requests
@@ -8,23 +10,41 @@ from goji.auth import get_credentials
 
 
 class JIRAClient(object):
-    def __init__(self, base_url):
+    def __init__(self, base_url, auth=None):
         self.session = requests.Session()
         self.base_url = base_url
         self.rest_base_url = urljoin(self.base_url, 'rest/api/2/')
+        self.session.auth = auth
+        self.load_cookies()
 
-        email, password = get_credentials(base_url)
+    # Persistent Cookie
 
-        if email is not None and password is not None:
-            self.auth = (email, password)
-            self.session.auth = self.auth
-        else:
-            print('== Authentication not configured. Run `goji login`')
-            exit()
+    @property
+    def cookie_path(self):
+        return os.path.expanduser('~/.goji/cookies')
 
-    def get(self, path):
+    def load_cookies(self):
+        if os.path.exists(self.cookie_path):
+            try:
+                with open(self.cookie_path, 'rb') as fp:
+                    self.session.cookies = pickle.load(fp)
+            except Exception as e:
+                print('warning: Could not load cookies from dist: ' + e)
+
+    def save_cookies(self):
+        if len(self.session.cookies) > 0:
+            os.makedirs(os.path.expanduser('~/.goji'), exist_ok=True)
+
+            with open(self.cookie_path, 'wb') as fp:
+                pickle.dump(self.session.cookies, fp)
+        elif os.path.exists(self.cookie_path):
+            os.remove(self.cookie_path)
+
+    # Methods
+
+    def get(self, path, **kwargs):
         url = urljoin(self.rest_base_url, path)
-        return self.session.get(url)
+        return self.session.get(url, **kwargs)
 
     def post(self, path, json):
         url = urljoin(self.rest_base_url, path)
@@ -39,7 +59,7 @@ class JIRAClient(object):
         return self.auth[0]
 
     def get_user(self):
-        response = self.get('myself')
+        response = self.get('myself', allow_redirects=False)
         response.raise_for_status()
         return User.from_json(response.json())
 

--- a/goji/commands.py
+++ b/goji/commands.py
@@ -2,13 +2,13 @@ import click
 from click_datetime import Datetime
 import requests
 from requests.compat import urljoin
-from requests_html import HTML
 
 from goji.client import JIRAClient
 from goji.auth import get_credentials, set_credentials
 
 
 def submit_form(session, response, data=None):
+    from requests_html import HTML
     html = HTML(url=response.url, html=response.text)
 
     forms = html.find('form')

--- a/goji/commands.py
+++ b/goji/commands.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 from click_datetime import Datetime
 import requests
@@ -36,6 +38,9 @@ def check_login(client):
     response = client.get('myself', allow_redirects=False)
 
     if response.status_code == 302:
+        if sys.version_info.major == 2:
+            raise click.ClickException('JIRA instances requires SSO login. goji requires Python 3 to do this. Please upgrade to Python 3')
+
         # JIRA API may redirect to SSO Authentication if auth fails
         # Manually follow redirect, some SSO requires browser user-agent
         response = client.get(response.headers['Location'], headers={
@@ -57,8 +62,7 @@ def check_login(client):
         client.save_cookies()
 
     if response.status_code == 401:
-        click.echo('Incorrect credentials. Try `goji login`.')
-        raise click.Abort()
+        raise click.ClickException('Incorrect credentials. Try `goji login`.')
 
 
 @click.group()

--- a/goji/commands.py
+++ b/goji/commands.py
@@ -76,7 +76,9 @@ def cli(ctx, base_url):
                 exit()
 
             ctx.obj = JIRAClient(base_url, auth=(email, password))
-            check_login(ctx.obj)
+
+            if len(ctx.obj.session.cookies) > 0:
+                check_login(ctx.obj)
 
 @cli.command('whoami')
 @click.pass_obj

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='Kyle Fuller',
     author_email='kyle@fuller.li',
     packages=('goji',),
-    install_requires=('requests', 'Click', 'click-datetime'),
+    install_requires=('requests', 'requests-html', 'Click', 'click-datetime'),
     entry_points={
         'console_scripts': (
             'goji = goji.commands:cli',


### PR DESCRIPTION
This is only tested on two JIRA instances with SSO that I have access to. Not all JIRA SSOs are the same, this may be a little coupled to my SSO implementation. Should be feasible to support others once we know how they work.

`requests-html` breaks Python 2 support. This feature will be Python 3 only, need to either drop Py2 support or alter code so SSO is not supported in Python 2.

#### Remaining Work

- [x] Fix Python 2
- [x] Test hosted non-SSO JIRA to see if it results in cookies. We can perhaps use cookie state to know if the JIRA uses SSO if the normal JIRA doesn't create cookies.