### PR TITLE
Allow specifying search format

### DIFF
--- a/goji/commands.py
+++ b/goji/commands.py
@@ -281,14 +281,22 @@ def login(base_url):
 
 
 @click.argument('query')
+@click.option('--format', default='{key} {summary}')
 @cli.command()
 @click.pass_obj
-def search(client, query):
+def search(client, format, query):
     """Search issues using JQL"""
+
     issues = client.search(query)
 
     for issue in issues:
-        click.echo('{issue.key} {issue.summary}'.format(issue=issue))
+        click.echo(format.replace('\\n', '\n').format(
+            key=issue.key,
+            summary=issue.summary,
+            description=issue.description,
+            creator=issue.creator,
+            assignee=issue.assignee,
+        ))
 
 
 @cli.group('sprint')

--- a/goji/models.py
+++ b/goji/models.py
@@ -37,6 +37,11 @@ class Issue(Model):
 
     def __init__(self, key):
         self.key = key
+        self.summary = None
+        self.description = None
+        self.creator = None
+        self.assignee = None
+        self.status = None
 
     def __str__(self):
         return self.key

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -40,6 +40,9 @@ class TestClient(object):
     def search(self, query):
         issue_7 = Issue('GOJI-7')
         issue_7.summary = 'My First Issue'
+        issue_7.description = 'One\nTwo\nThree\n'
+        issue_7.creator = User('kyle', 'Kyle Fuller')
+        issue_7.assignee = User('delisa', 'Delisa')
 
         return [
             issue_7
@@ -124,6 +127,41 @@ class SearchCommandTests(unittest.TestCase):
         result = runner.invoke(cli, args, obj=TestClient())
         self.assertIsNone(result.exception)
         self.assertEqual(result.output, 'GOJI-7 My First Issue\n')
+
+    def test_search_format_key(self):
+        runner = CliRunner()
+        args = ['--base-url=https://example.com', 'search', '--format={key}', 'PROJECT=GOJI']
+        result = runner.invoke(cli, args, obj=TestClient())
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.output, 'GOJI-7\n')
+
+    def test_search_format_summary(self):
+        runner = CliRunner()
+        args = ['--base-url=https://example.com', 'search', '--format={summary}', 'PROJECT=GOJI']
+        result = runner.invoke(cli, args, obj=TestClient())
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.output, 'My First Issue\n')
+
+    def test_search_format_description(self):
+        runner = CliRunner()
+        args = ['--base-url=https://example.com', 'search', '--format={description}', 'PROJECT=GOJI']
+        result = runner.invoke(cli, args, obj=TestClient())
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.output, 'One\nTwo\nThree\n\n')
+
+    def test_search_format_creator(self):
+        runner = CliRunner()
+        args = ['--base-url=https://example.com', 'search', '--format={creator}', 'PROJECT=GOJI']
+        result = runner.invoke(cli, args, obj=TestClient())
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.output, 'Kyle Fuller (kyle)\n')
+
+    def test_search_format_assignee(self):
+        runner = CliRunner()
+        args = ['--base-url=https://example.com', 'search', '--format={assignee}', 'PROJECT=GOJI']
+        result = runner.invoke(cli, args, obj=TestClient())
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.output, 'Delisa (delisa)\n')
 
 
 class NewCommandTests(unittest.TestCase):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,7 +4,7 @@ import os
 from click.testing import CliRunner
 
 from goji.commands import cli
-from goji.models import User, Issue, Transition
+from goji.models import User, Issue, Transition, Issue
 
 
 class TestClient(object):
@@ -36,6 +36,14 @@ class TestClient(object):
 
     def change_status(self, issue_key, transition_id):
         return True
+
+    def search(self, query):
+        issue_7 = Issue('GOJI-7')
+        issue_7.summary = 'My First Issue'
+
+        return [
+            issue_7
+        ]
 
 
 class CLITests(unittest.TestCase):
@@ -107,6 +115,15 @@ class ChangeStatusCommandTests(unittest.TestCase):
         result = runner.invoke(cli, args, obj=TestClient())
         self.assertIsNone(result.exception)
         self.assertEqual(result.output, 'Fetching possible transitions...\nOkay, the status for GOJI-311 is now "Done".\n')
+
+
+class SearchCommandTests(unittest.TestCase):
+    def test_search(self):
+        runner = CliRunner()
+        args = ['--base-url=https://example.com', 'search', 'PROJECT=GOJI']
+        result = runner.invoke(cli, args, obj=TestClient())
+        self.assertIsNone(result.exception)
+        self.assertEqual(result.output, 'GOJI-7 My First Issue\n')
 
 
 class NewCommandTests(unittest.TestCase):


### PR DESCRIPTION
Currently search formats permitted:

- key
- summary
- description
- creator
- assignee

Example:

```
$ goji search --format={key} {summary}
```