### PR TITLE
Rewrite some command tests to use JIRAServer

### DIFF
--- a/tests/server.py
+++ b/tests/server.py
@@ -47,6 +47,12 @@ class JIRAServer(object):
                 handler.handle_request('PUT')
 
             def handle_request(handler, method):
+                if self.require_method and method != self.require_method:
+                    raise Exception('Client called incorrect method')
+
+                if self.require_path and handler.path != self.require_path:
+                    raise Exception('Client called incorrect path: ' + handler.path)
+
                 if 'Content-Length' in handler.headers and \
                         handler.headers['Content-Type'] == 'application/json':
                     length = int(handler.headers['Content-Length'])
@@ -97,3 +103,14 @@ class JIRAServer(object):
         self.server.shutdown()
         self.thread.join()
         self.server.server_close()
+
+    def set_user_response(self):
+        self.require_method = 'GET'
+        self.require_path = '/rest/api/2/myself'
+
+        self.response.status_code = 200
+        self.response.body = {
+            'name': 'kyle',
+            'displayName': 'Kyle Fuller',
+            'emailAddress': 'kyle@example.com',
+        }

--- a/tests/server.py
+++ b/tests/server.py
@@ -120,3 +120,29 @@ class JIRAServer(object):
         self.require_path = '/rest/api/2/issue/{}/assignee'.format(issue_key)
 
         self.response.status_code = 204
+
+    def set_search_response(self):
+        self.require_method = 'POST'
+        self.require_path = '/rest/api/2/search'
+
+        self.response.status_code = 200
+        self.response.body = {
+            'issues': [
+                {
+                    'key': 'GOJI-7',
+                    'fields': {
+                        'summary': 'My First Issue',
+                        'description': 'One\nTwo\nThree\n',
+                        'status': {'name': 'open'},
+                        'creator': {
+                            'displayName': 'Kyle Fuller',
+                            'name': 'kyle'
+                        },
+                        'assignee': {
+                            'displayName': 'Delisa',
+                            'name': 'delisa'
+                        }
+                    }
+                }
+            ]
+        }

--- a/tests/server.py
+++ b/tests/server.py
@@ -114,3 +114,9 @@ class JIRAServer(object):
             'displayName': 'Kyle Fuller',
             'emailAddress': 'kyle@example.com',
         }
+
+    def set_assign_response(self, issue_key):
+        self.require_method = 'PUT'
+        self.require_path = '/rest/api/2/issue/{}/assignee'.format(issue_key)
+
+        self.response.status_code = 204

--- a/tests/server.py
+++ b/tests/server.py
@@ -115,6 +115,28 @@ class JIRAServer(object):
             'emailAddress': 'kyle@example.com',
         }
 
+    def set_issue_response(self, issue_key='GOJI-1'):
+        self.require_method = 'GET'
+        self.require_path = '/rest/api/2/issue/{}'.format(issue_key)
+
+        self.response.status_code = 200
+        self.response.body = {
+            'key': issue_key,
+            'fields': {
+                'summary': 'Example Issue',
+                'description': 'Issue Description',
+                'status': {'name': 'Open'},
+                'creator': {
+                    'displayName': 'Kyle Fuller',
+                    'name': 'kyle'
+                },
+                'assignee': {
+                    'displayName': 'Delisa',
+                    'name': 'delisa'
+                }
+            }
+        }
+
     def set_assign_response(self, issue_key):
         self.require_method = 'PUT'
         self.require_path = '/rest/api/2/issue/{}/assignee'.format(issue_key)

--- a/tests/server.py
+++ b/tests/server.py
@@ -1,7 +1,21 @@
+import unittest
 import json
 from threading import Thread
 
 from six.moves import BaseHTTPServer
+
+
+class ServerTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = JIRAServer()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+
+    def setUp(self):
+        self.server.reset()
 
 
 class Request(object):
@@ -20,8 +34,7 @@ class Response(object):
 
 class JIRAServer(object):
     def __init__(self):
-        self.requests = []
-        self.response = Response(200, None)
+        self.reset()
 
         class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
             def do_GET(handler):
@@ -73,6 +86,12 @@ class JIRAServer(object):
     @property
     def last_request(self):
         return self.requests[-1]
+
+    def reset(self):
+        self.requests = []
+        self.response = Response(200, None)
+        self.require_method = None
+        self.require_path = None
 
     def shutdown(self):
         self.server.shutdown()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -141,7 +141,8 @@ class ClientTests(ServerTestCase):
                     'key': 'GOJI-1',
                     'fields': {
                         'summary': 'Hello World',
-                        'status': {'name': 'open'}
+                        'description': 'One\nTwo\nThree\n',
+                        'status': {'name': 'open'},
                     }
                 }
             ],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,22 +3,13 @@ import datetime
 
 from goji.client import JIRAClient, JIRAException
 
-from tests.server import JIRAServer
+from tests.server import ServerTestCase
 
 
-class ClientTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.server = JIRAServer()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.server.shutdown()
-
+class ClientTests(ServerTestCase):
     def setUp(self):
+        super(ClientTests, self).setUp()
         self.client = JIRAClient(self.server.url)
-        self.server.response.status_code = 200
-        self.server.response.body = None
 
     def test_post_400_error(self):
         self.server.response.status_code = 400

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -35,17 +35,6 @@ class TestClient(object):
     def change_status(self, issue_key, transition_id):
         return True
 
-    def search(self, query):
-        issue_7 = Issue('GOJI-7')
-        issue_7.summary = 'My First Issue'
-        issue_7.description = 'One\nTwo\nThree\n'
-        issue_7.creator = User('kyle', 'Kyle Fuller')
-        issue_7.assignee = User('delisa', 'Delisa')
-
-        return [
-            issue_7
-        ]
-
 
 class CommandTestCase(ServerTestCase):
     def invoke(self, *args):
@@ -166,48 +155,60 @@ class ChangeStatusCommandTests(unittest.TestCase):
         self.assertEqual(result.output, 'Fetching possible transitions...\nOkay, the status for GOJI-311 is now "Done".\n')
 
 
-class SearchCommandTests(unittest.TestCase):
+class SearchCommandTests(CommandTestCase):
     def test_search(self):
-        runner = CliRunner()
-        args = ['--base-url=https://example.com', 'search', 'PROJECT=GOJI']
-        result = runner.invoke(cli, args, obj=TestClient())
+        self.server.set_search_response()
+
+        result = self.invoke('search', 'PROJECT=GOJI')
+
         self.assertIsNone(result.exception)
         self.assertEqual(result.output, 'GOJI-7 My First Issue\n')
+        self.assertEqual(result.exit_code, 0)
 
     def test_search_format_key(self):
-        runner = CliRunner()
-        args = ['--base-url=https://example.com', 'search', '--format={key}', 'PROJECT=GOJI']
-        result = runner.invoke(cli, args, obj=TestClient())
+        self.server.set_search_response()
+
+        result = self.invoke('search', '--format', '{key}', 'PROJECT=GOJI')
+
         self.assertIsNone(result.exception)
         self.assertEqual(result.output, 'GOJI-7\n')
+        self.assertEqual(result.exit_code, 0)
 
     def test_search_format_summary(self):
-        runner = CliRunner()
-        args = ['--base-url=https://example.com', 'search', '--format={summary}', 'PROJECT=GOJI']
-        result = runner.invoke(cli, args, obj=TestClient())
+        self.server.set_search_response()
+
+        result = self.invoke('search', '--format', '{summary}', 'PROJECT=GOJI')
+
         self.assertIsNone(result.exception)
         self.assertEqual(result.output, 'My First Issue\n')
+        self.assertEqual(result.exit_code, 0)
 
     def test_search_format_description(self):
-        runner = CliRunner()
-        args = ['--base-url=https://example.com', 'search', '--format={description}', 'PROJECT=GOJI']
-        result = runner.invoke(cli, args, obj=TestClient())
+        self.server.set_search_response()
+
+        result = self.invoke('search', '--format', '{description}', 'PROJECT=GOJI')
+
         self.assertIsNone(result.exception)
         self.assertEqual(result.output, 'One\nTwo\nThree\n\n')
+        self.assertEqual(result.exit_code, 0)
 
     def test_search_format_creator(self):
-        runner = CliRunner()
-        args = ['--base-url=https://example.com', 'search', '--format={creator}', 'PROJECT=GOJI']
-        result = runner.invoke(cli, args, obj=TestClient())
+        self.server.set_search_response()
+
+        result = self.invoke('search', '--format', '{creator}', 'PROJECT=GOJI')
+
         self.assertIsNone(result.exception)
         self.assertEqual(result.output, 'Kyle Fuller (kyle)\n')
+        self.assertEqual(result.exit_code, 0)
 
     def test_search_format_assignee(self):
-        runner = CliRunner()
-        args = ['--base-url=https://example.com', 'search', '--format={assignee}', 'PROJECT=GOJI']
-        result = runner.invoke(cli, args, obj=TestClient())
+        self.server.set_search_response()
+
+        result = self.invoke('search', '--format', '{assignee}', 'PROJECT=GOJI')
+
         self.assertIsNone(result.exception)
         self.assertEqual(result.output, 'Delisa (delisa)\n')
+        self.assertEqual(result.exit_code, 0)
 
 
 class NewCommandTests(unittest.TestCase):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -14,16 +14,6 @@ class TestClient(object):
     base_url = 'https://goji.example.com/'
     username = 'kyle'
 
-    def get_issue(self, issue_key):
-        issue = Issue(issue_key)
-        issue.summary = 'Example issue'
-        issue.description = None
-        issue.status = 'Open'
-        issue.creator = 'kyle'
-        issue.assignee = 'kyle'
-        issue.links = []
-        return issue
-
     def get_issue_transitions(self, issue_key):
         if issue_key == 'invalid':
             return []
@@ -54,19 +44,33 @@ class CLITests(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
 
 
-class ShowCommandTests(unittest.TestCase):
+class ShowCommandTests(CommandTestCase):
     def test_show__without_issue_key(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ['--base-url=https://example.com', 'show'], obj=TestClient())
+        result = self.invoke('show')
 
         self.assertTrue('Error: Missing argument "issue_key"' in result.output)
         self.assertNotEqual(result.exit_code, 0)
 
     def test_show_with_issue_key(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ['--base-url=https://example.com', 'show', 'XX-123'], obj=TestClient())
+        self.server.set_issue_response()
 
-        self.assertEqual(result.output, '-> XX-123\n  Example issue\n\n  - Status: Open\n  - Creator: kyle\n  - Assigned: kyle\n  - URL: https://goji.example.com/browse/XX-123\n')
+        result = self.invoke('show', 'GOJI-1')
+        output = result.output.replace(self.server.url, 'https://example.com')
+
+        print(result.output)
+
+        expected = '''-> GOJI-1
+  Example Issue
+
+  Issue Description
+
+  - Status: Open
+  - Creator: Kyle Fuller (kyle)
+  - Assigned: Delisa (delisa)
+  - URL: https://example.com/browse/GOJI-1
+'''
+
+        self.assertEqual(output, expected)
         self.assertEqual(result.exit_code, 0)
 
 


### PR DESCRIPTION
The problem with the mocked TestClient is that it doesn't test the client is calling the actual client correctly. This refactors the tests to use JIRAServer