### PR TITLE
Don't send authentication headers while using cookies

### DIFF
--- a/goji/client.py
+++ b/goji/client.py
@@ -28,8 +28,9 @@ class JIRAClient(object):
         self.session = requests.Session()
         self.base_url = base_url
         self.rest_base_url = urljoin(self.base_url, 'rest/api/2/')
-        self.session.auth = auth
         self.load_cookies()
+        self.auth = auth
+        #self.session.auth = auth
 
     # Persistent Cookie
 
@@ -84,7 +85,7 @@ class JIRAClient(object):
 
     @property
     def username(self):
-        return self.session.auth[0]
+        return self.auth[0]
 
     def get_user(self):
         response = self.get('myself', allow_redirects=False)

--- a/goji/commands.py
+++ b/goji/commands.py
@@ -47,7 +47,7 @@ def check_login(client):
             'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'
         })
 
-        auth = client.session.auth
+        auth = client.auth
         client.session.auth = None
 
         if '<body onLoad="document.myForm.submit()">' in response.text or '<body onLoad="submitForm()">' in response.text:


### PR DESCRIPTION
When cookies are used for authentication (for example with SSO) we don't want to sent authentication header, this can cause other problems.

This is a little tricky to make the behaviour automatic for both normal JIRA and crazy JIRA with SSO thus haven't been able to make it work (and its also hard to test all cases with different types of JIRA instances and how they handle authentication).

At the moment this branch breaks goji for JIRA with basic auth so do not merge.