### PR TITLE
Fix a crash when issue description contains unicode.

### DIFF
--- a/goji/commands.py
+++ b/goji/commands.py
@@ -114,7 +114,7 @@ def show(client, issue_key):
 
     if issue.description:
         for line in issue.description.splitlines():
-            click.echo('  {}'.format(line))
+            click.echo(u'  {}'.format(line))
 
         click.echo('')
 


### PR DESCRIPTION
If you try to show an issue that contains unicode, it will display fine until it hits the line with an offending character and then throws:

```
Traceback (most recent call last):
  File "/usr/local/bin/goji", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/decorators.py", line 27, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/goji/commands.py", line 117, in show
    click.echo('  {}'.format(line))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u27a4' in position 18: ordinal not in range(128)
```

Herein, I change the `'  {}'.format(line)` to `u'  {}'.format(line)` so it can safely handle unicode input.