### PR TITLE
Allow supplying `--email` and `--password` to login

### DIFF
--- a/goji/commands.py
+++ b/goji/commands.py
@@ -289,18 +289,24 @@ def create(client, project, summary, type, component, label, priority, descripti
 
 
 @cli.command()
+@click.option('--email')
+@click.option('--password', hide_input=True)
 @click.pass_obj
-def login(base_url):
+def login(base_url, email, password):
     """Authenticate with JIRA server"""
-    email, password = get_credentials(base_url)
-    if email is not None:
+    existing_email, existing_password = get_credentials(base_url)
+    if existing_email is not None:
         if not click.confirm('This server is already configured. Override?'):
             return
 
-    click.echo('Enter your JIRA credentials')
+    if not email or not password:
+        click.echo('Enter your JIRA credentials')
 
-    email = click.prompt('Email', type=str)
-    password = click.prompt('Password', type=str, hide_input=True)
+    if not email:
+        email = click.prompt('Email', type=str)
+
+    if not password:
+        password = click.prompt('Password', type=str, hide_input=True)
 
     client = JIRAClient(base_url, auth=(email, password))
     check_login(client)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -106,6 +106,19 @@ class LoginCommandTests(CommandTestCase):
         self.assertTrue('Error: Incorrect credentials. Try `goji login`.' in result.output)
         self.assertEqual(result.exit_code, 1)
 
+    def test_login_with_credentials_in_options(self):
+        self.server.set_user_response()
+
+        with self.runner.isolated_filesystem():
+            result = self.invoke('login', '--email', 'email', '--password', 'password', client=None)
+
+            with open(os.path.expanduser('~/.netrc')) as fp:
+                self.assertEqual(fp.read(), 'machine 127.0.0.1\n  login email\n  password password')
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(self.server.last_request.headers['Authorization'],
+                         'Basic ZW1haWw6cGFzc3dvcmQ=')
+
 
 class ShowCommandTests(CommandTestCase):
     def test_show__without_issue_key(self):


### PR DESCRIPTION
```
$ goji login --email kyle@fuller.li --password "Hello World"
```

I'd like to move password to be stdin, shouldn't be as option.